### PR TITLE
Initialize expense app skeleton

### DIFF
--- a/ExpenseApp/.gitignore
+++ b/ExpenseApp/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+.expo
+web-build
+*.sqlite

--- a/ExpenseApp/App.js
+++ b/ExpenseApp/App.js
@@ -1,0 +1,78 @@
+import React, { useState, useEffect } from 'react';
+import { NavigationContainer } from '@react-navigation/native';
+import { createStackNavigator } from '@react-navigation/stack';
+import { View, Text, TextInput, Button, FlatList } from 'react-native';
+import * as SQLite from 'expo-sqlite';
+
+const db = SQLite.openDatabase('expenses.sqlite');
+
+function initDb() {
+  db.transaction(tx => {
+    tx.executeSql(
+      'CREATE TABLE IF NOT EXISTS expenses (id INTEGER PRIMARY KEY AUTOINCREMENT, amount REAL, method TEXT, note TEXT, date TEXT)'
+    );
+  });
+}
+
+function addExpense(amount, method, note) {
+  db.transaction(tx => {
+    tx.executeSql('INSERT INTO expenses (amount, method, note, date) values (?, ?, ?, date(\'now\'))', [amount, method, note]);
+  });
+}
+
+function getExpenses(setExpenses) {
+  db.transaction(tx => {
+    tx.executeSql('SELECT * FROM expenses ORDER BY date DESC', [], (_, { rows }) => {
+      setExpenses(rows._array);
+    });
+  });
+}
+
+function ExpenseEntryScreen({ navigation }) {
+  const [amount, setAmount] = useState('');
+  const [method, setMethod] = useState('cash');
+  const [note, setNote] = useState('');
+
+  return (
+    <View style={{ padding: 20 }}>
+      <Text>Amount</Text>
+      <TextInput value={amount} onChangeText={setAmount} keyboardType="numeric" style={{ borderWidth: 1, marginBottom: 10 }} />
+      <Text>Method (cash/credit)</Text>
+      <TextInput value={method} onChangeText={setMethod} style={{ borderWidth: 1, marginBottom: 10 }} />
+      <Text>Note</Text>
+      <TextInput value={note} onChangeText={setNote} style={{ borderWidth: 1, marginBottom: 10 }} />
+      <Button title="Save" onPress={() => { addExpense(parseFloat(amount), method, note); setAmount(''); setNote(''); }} />
+      <Button title="View Report" onPress={() => navigation.navigate('Report')} />
+    </View>
+  );
+}
+
+function ReportScreen() {
+  const [expenses, setExpenses] = useState([]);
+  useEffect(() => { getExpenses(setExpenses); }, []);
+
+  const total = expenses.reduce((sum, e) => sum + e.amount, 0);
+
+  return (
+    <View style={{ flex: 1, padding: 20 }}>
+      <Text>Total: {total}</Text>
+      <FlatList data={expenses} keyExtractor={item => item.id.toString()} renderItem={({ item }) => (
+        <Text>{item.date} - {item.method}: {item.amount} ({item.note})</Text>
+      )} />
+    </View>
+  );
+}
+
+const Stack = createStackNavigator();
+
+export default function App() {
+  useEffect(() => { initDb(); }, []);
+  return (
+    <NavigationContainer>
+      <Stack.Navigator>
+        <Stack.Screen name="Entry" component={ExpenseEntryScreen} />
+        <Stack.Screen name="Report" component={ReportScreen} />
+      </Stack.Navigator>
+    </NavigationContainer>
+  );
+}

--- a/ExpenseApp/package.json
+++ b/ExpenseApp/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "expenseapp",
+  "version": "1.0.0",
+  "private": true,
+  "main": "node_modules/expo/AppEntry.js",
+  "scripts": {
+    "start": "expo start",
+    "android": "expo start --android",
+    "ios": "expo start --ios"
+  },
+  "dependencies": {
+    "expo": "^50.0.0",
+    "react": "18.2.0",
+    "react-native": "0.73.0",
+    "expo-sqlite": "^11.0.0",
+    "@react-navigation/native": "^6.1.6",
+    "@react-navigation/stack": "^6.3.16",
+    "node-fetch": "^3.3.2"
+  }
+}

--- a/ExpenseApp/sync.js
+++ b/ExpenseApp/sync.js
@@ -1,0 +1,61 @@
+const fs = require('fs');
+const fetch = require('node-fetch');
+
+const token = process.env.GH_TOKEN;
+const repo = process.env.GH_REPO; // e.g. user/private-repo
+const path = 'expenses.sqlite';
+const apiBase = 'https://api.github.com';
+
+if (!token || !repo) {
+  console.error('GH_TOKEN and GH_REPO env vars required');
+  process.exit(1);
+}
+
+async function getFileSha() {
+  const res = await fetch(`${apiBase}/repos/${repo}/contents/${path}`, {
+    headers: { 'Authorization': `token ${token}` }
+  });
+  if (res.status === 404) return null;
+  const data = await res.json();
+  return data.sha;
+}
+
+async function pushFile() {
+  const content = fs.readFileSync(path, 'base64');
+  const sha = await getFileSha();
+  const res = await fetch(`${apiBase}/repos/${repo}/contents/${path}`, {
+    method: 'PUT',
+    headers: {
+      'Authorization': `token ${token}`,
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify({
+      message: 'Sync DB',
+      content,
+      sha
+    })
+  });
+  if (!res.ok) {
+    console.error('Push failed', await res.text());
+    process.exit(1);
+  }
+  console.log('Pushed');
+}
+
+async function pullFile() {
+  const res = await fetch(`${apiBase}/repos/${repo}/contents/${path}`, {
+    headers: { 'Authorization': `token ${token}` }
+  });
+  if (!res.ok) {
+    console.error('Pull failed', await res.text());
+    process.exit(1);
+  }
+  const data = await res.json();
+  fs.writeFileSync(path, Buffer.from(data.content, 'base64'));
+  console.log('Pulled');
+}
+
+const cmd = process.argv[2];
+if (cmd === 'push') pushFile();
+else if (cmd === 'pull') pullFile();
+else console.log('Usage: node sync.js [push|pull]');

--- a/README.md
+++ b/README.md
@@ -1,0 +1,35 @@
+# ExpenseApp
+
+This React Native (Expo) project allows daily expense entry and reporting using a local SQLite database. It also provides a simple sync script to push/pull the database file to a private GitHub repository.
+
+## Prerequisites
+
+- Node.js 18+ and npm
+- Expo CLI (`npm install -g expo-cli`)
+- A private GitHub repository and personal access token for syncing
+
+## Setup
+
+```bash
+cd ExpenseApp
+npm install
+```
+
+## Running
+
+```bash
+npm start           # start Expo
+npm run android     # run on Android
+npm run ios         # run on iOS
+```
+
+## Syncing Database
+
+Set environment variables `GH_TOKEN` (GitHub token) and `GH_REPO` (`owner/repo`). Then run:
+
+```bash
+node sync.js push   # upload expenses.sqlite to repo
+node sync.js pull   # download expenses.sqlite from repo
+```
+
+The script updates `expenses.sqlite` in the repository using the GitHub Contents API.


### PR DESCRIPTION
## Summary
- create React Native (Expo) skeleton under `ExpenseApp`
- implement local SQLite expense entry and report screens
- add GitHub sync script
- document project usage in README

## Testing
- `node -v`
- `npm init -y`

------
https://chatgpt.com/codex/tasks/task_b_685fde7d2c5c832f957e9963723aec4b